### PR TITLE
docs: update README and add godoc comments (by Gemini 3 Pro)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,23 @@ The example uses the following frameworks:
 Clone the repository and execute the following command on the root folder
 
 ``` bash
-go run main.go
+make run
 ```
 
 ## Test
 
 ``` bash
-go test ./...
+make test
+```
+
+## Lint
+
+``` bash
+make lint
 ```
 
 ## Backlog
 
 > This is a work in progress. There's still a lot of work to do. PRs are welcome :)
-* Add (a LOT) of unit tests
-* Use `Context` type to pass parameters across different layers
 * Add an example of database handler module
 

--- a/api/messagectrl.go
+++ b/api/messagectrl.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hdlopez/clean-architecture-golang/message"
 )
 
+// MessageController interface defines the methods for message controller
 type MessageController interface {
 	Get(c Ctx)
 }

--- a/apierror/apierror.go
+++ b/apierror/apierror.go
@@ -5,6 +5,7 @@ func New(code int, message string) *APIError {
 	return &APIError{code, message}
 }
 
+// FromError creates a new APIError from a standard error
 func FromError(err error) *APIError {
 	return New(500, err.Error())
 }

--- a/config/config.go
+++ b/config/config.go
@@ -5,9 +5,11 @@ import (
 )
 
 const (
+	// MessageAPI is the name of the message API client
 	MessageAPI = "MessageAPI"
 )
 
+// RestClients returns a map of configured resty clients
 func RestClients() map[string]*resty.Client {
 	restClients := map[string]*resty.Client{
 		MessageAPI: resty.New(),

--- a/message/message.go
+++ b/message/message.go
@@ -2,10 +2,12 @@ package message
 
 import "github.com/hdlopez/clean-architecture-golang/restclient"
 
+// Message entity
 type Message struct {
 	Text string `json:"text"`
 }
 
+// build creates a new Message from restclient.Message
 func build(msg *restclient.Message) *Message {
 	return &Message{msg.Text}
 }

--- a/message/repository.go
+++ b/message/repository.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hdlopez/clean-architecture-golang/restclient"
 )
 
+// Repository interface defines the methods for message repository
 type Repository interface {
 	Get(ctx context.Context, id string) (*Message, error)
 }
@@ -16,6 +17,7 @@ type msgRepo struct {
 	api restclient.MessageAPI
 }
 
+// NewRepository creates a new instance of Repository
 func NewRepository(api restclient.MessageAPI) Repository {
 	repo := new(msgRepo)
 	repo.api = api

--- a/message/service.go
+++ b/message/service.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hdlopez/clean-architecture-golang/apierror"
 )
 
+// Service interface defines the methods for message service
 type Service interface {
 	Get(ctx context.Context, ID string) (*Message, error)
 }
@@ -14,6 +15,7 @@ type messageSrv struct {
 	repo Repository
 }
 
+// NewService creates a new instance of Service
 func NewService(r Repository) Service {
 	srv := new(messageSrv)
 	srv.repo = r

--- a/restclient/messageapi.go
+++ b/restclient/messageapi.go
@@ -13,6 +13,7 @@ var (
 	messageAPIURL = "http://localhost:3000/messages/%s"
 )
 
+// MessageAPI interface defines the methods for message API client
 type MessageAPI interface {
 	Get(ctx context.Context, id string) (*Message, error)
 }
@@ -21,10 +22,12 @@ type msgAPI struct {
 	restAPI
 }
 
+// Message entity for restclient
 type Message struct {
 	Text string `json:"text"`
 }
 
+// NewMessageAPI creates a new instance of MessageAPI
 func NewMessageAPI(c *resty.Client) MessageAPI {
 	api := new(msgAPI)
 	api.readClient = c


### PR DESCRIPTION
## Summary
This PR improves the project documentation by updating the README and adding Godoc comments to the codebase.
**These changes were implemented by Gemini 3 Pro.**

## Changes
- **README.md**: Updated instructions to use `make` commands for running, testing, and linting the application. Removed outdated backlog items.
- **Godoc**: Added comments to all exported types and functions in [config](cci:1://file:///Users/hlopez/Dev/github.com/hdlopez/clean-architecture-golang/api/api.go:41:0-45:1), `api`, [message](cci:2://file:///Users/hlopez/Dev/github.com/hdlopez/clean-architecture-golang/message/service.go:13:0-15:1), `restclient`, and `apierror` packages to improve code readability and documentation.

## Verification
- Verified that `make run`, `make test`, and `make lint` commands are documented correctly.
- Ensured all exported symbols have appropriate comments.